### PR TITLE
🐛 fix(react-button): Console error for refs.

### DIFF
--- a/packages/react-button/lib/button.js
+++ b/packages/react-button/lib/button.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Button = ({
+const Button = React.forwardRef( ({
 	label,
 	icon,
 	design = "solid",
@@ -84,6 +84,6 @@ const Button = ({
 			{props.loading ? loader : content}
 		</button>
 	);
-};
+});
 
 export { Button };


### PR DESCRIPTION
Function components cannot be given ref when using react-router-dom.