### PR TITLE
🐛 fix(react-dropdown): Clicking on its options closes the menu.

### DIFF
--- a/packages/react-dropdown/lib/react-dropdown.js
+++ b/packages/react-dropdown/lib/react-dropdown.js
@@ -11,6 +11,7 @@ export class Dropdown extends Component {
 
         this.toggle = this.toggle.bind( this );
 
+		this.wrapperRef = React.createRef();
         this.setWrapperRef = this.setWrapperRef.bind( this );
         this.handleClickOutside = this.handleClickOutside.bind( this );
     }
@@ -93,9 +94,8 @@ export class Dropdown extends Component {
         }
 
         return (
-            <div className={ clazz }>
+            <div className={ clazz } ref={ this.setWrapperRef }>
                 <ButtonIcon
-                    ref={ this.setWrapperRef }
                     icon="widget-settings-config"
                     label={ open ? 'Open menu' : 'Close menu' }
                     onClick={ ( e ) => this.toggle( e ) }

--- a/packages/react-dropdown/lib/react-dropdown.js
+++ b/packages/react-dropdown/lib/react-dropdown.js
@@ -98,7 +98,7 @@ export class Dropdown extends Component {
                 <ButtonIcon
                     icon="widget-settings-config"
                     label={ open ? 'Open menu' : 'Close menu' }
-                    onClick={ ( e ) => this.toggle( e ) }
+                    onClick={ this.toggle }
                 />
                 { open && <ul>{ options }</ul> }
             </div>


### PR DESCRIPTION
This prevents the actions bond "onClick" to the options from being executed.