### PR TITLE
🐛 fix(Post): read more misaligns when reading time is missing

### DIFF
--- a/packages/react-post/lib/react-post.js
+++ b/packages/react-post/lib/react-post.js
@@ -99,6 +99,7 @@ const PostFooter = styled.div`
 	flex-flow: row wrap;
 	align-items: center;
 	margin-top: 15px;
+	min-height: 30px;
 `;
 
 const FeaturedImage = styled.div.attrs(() => ({
@@ -186,7 +187,8 @@ const ReadMore = styled.p`
 	line-height: 18px !important;
 	font-weight: 500 !important;
 	letter-spacing: -0.2px !important;
-	margin-bottom: 13px;
+	margin-bottom: 0;
+	align-self: flex-start;
 `;
 
 export class Post extends Component {

--- a/packages/react-post/lib/react-post.js
+++ b/packages/react-post/lib/react-post.js
@@ -186,6 +186,7 @@ const ReadMore = styled.p`
 	line-height: 18px !important;
 	font-weight: 500 !important;
 	letter-spacing: -0.2px !important;
+	margin-bottom: 13px;
 `;
 
 export class Post extends Component {


### PR DESCRIPTION
Added `margin-bottom : 13px` to maintain styling when reading time is missing.